### PR TITLE
update instructions for matgen node

### DIFF
--- a/MPenv/mpenv.py
+++ b/MPenv/mpenv.py
@@ -1,7 +1,7 @@
 
 
 from argparse import ArgumentParser
-import os, time
+import os, time, re
 from os.path import expanduser
 import shutil
 import string
@@ -34,6 +34,12 @@ def create_env():
     else:
       print 'OK, will install brand-new {} environment'.format(args.name)
 
+    BASHRC_FILE = os.path.join(expanduser("~"), ".bashrc.ext")
+    with open(BASHRC_FILE, 'r') as f:
+	if re.search(r'<---MPenv {}'.format(args.name), f.read()):
+	    print 'ERROR: make sure to remove {} section from {}!'.format(args.name, BASHRC_FILE)
+	    return
+
     print '3 seconds time to abort ...'
     time.sleep(3)
 
@@ -43,16 +49,17 @@ def create_env():
     files_dir = os.path.join(root_dir, args.name+CONFIG_TAG)
     codes_dir = os.path.join(root_dir, args.name, 'codes')
 
-    BASHRC_FILE = os.path.join(expanduser("~"), ".bashrc.ext")
     MACHINES = ('Mendel', 'Hopper', 'Vesta', 'Edison')  # note: you must modify BASH_template.txt when adding machines
 
     print 'VALIDATING DIRECTORY'
     envtype = "FW"
     if not os.path.exists(files_dir):
-        raise ValueError("Files directory: {} does not exist! Please make sure you are typing the ENVIRONMENT name and not the directory name.".format(files_dir))
+	print "ERROR: Files directory {} does not exist! Please make sure you are typing the ENVIRONMENT name and not the directory name.".format(files_dir)
+	return
 
     if not os.path.exists(os.path.join(files_dir, 'my_launchpad.yaml')):
-        raise ValueError("Missing file: {}".format(files_dir, 'my_launchpad.yaml'))
+	print "ERROR: Missing file: {}".format(files_dir, 'my_launchpad.yaml')
+	return
 
     if os.path.exists(os.path.join(files_dir, 'tasks_db.json')):
         envtype = "MP"

--- a/MPenv/mpenv.py
+++ b/MPenv/mpenv.py
@@ -70,11 +70,15 @@ def create_env():
     print 'OK, we are going to install a {} environment'.format(envtype)
 
     c = []
-    c.append(('print', 'SETTING UP VIRTUALENV'))
     c.append(("mkdir", args.name))
     c.append(("cd", args.name))
-    c.append(("mkdir", "virtenv_{}".format(args.name)))
-    c.append("virtualenv --no-site-packages virtenv_{}".format(args.name))
+
+    if not os.path.exists(os.path.join(root_dir, args.name, "virtenv_{}".format(args.name))):
+	c.append(('print', 'SETTING UP VIRTUALENV'))
+	c.append(("mkdir", "virtenv_{}".format(args.name)))
+	c.append("virtualenv --no-site-packages virtenv_{}".format(args.name))
+
+    c.append(('print', 'ACTIVATE VIRTUALENV'))
     c.append(("activate", os.path.join(root_dir, args.name, 'virtenv_{}/bin/activate_this.py'.format(args.name))))
     c.append(("mkdir", "codes"))
     c.append(("cd", 'codes'))

--- a/MPenv/mpenv_static/BASH_template.txt
+++ b/MPenv/mpenv_static/BASH_template.txt
@@ -7,10 +7,13 @@ alias update_codes='python $SCRIPT_LOC/update_codes.py'
 if [ "$NERSC_HOST" == "matgen" ]
 then
    module load vim
+   module load intel
    module load python/2.7.3
    module swap numpy numpy/1.8.1
    module load virtualenv
    module load virtualenvwrapper
+   module use /usr/common/das/Modules/modulefiles
+   module load vasp/5.2
    export FW_CONFIG_$$NAME='$$CONFIG_LOC/config_Mendel/FW_config.yaml'
    # Load Boltztrap
    export PATH=$PATH:/project/projectdirs/matgen/boltztrap/boltztrap-1.2.3/src

--- a/MPenv/mpenv_static/BASH_template.txt
+++ b/MPenv/mpenv_static/BASH_template.txt
@@ -7,11 +7,11 @@ alias update_codes='python $SCRIPT_LOC/update_codes.py'
 if [ "$NERSC_HOST" == "carver" ]
 then
    module load python/2.7.3
-   module load numpy/1.8.1
    export FW_CONFIG_$$NAME='$$CONFIG_LOC/config_Mendel/FW_config.yaml'
    # Load Boltztrap
    export PATH=$PATH:/project/projectdirs/matgen/boltztrap/boltztrap-1.2.3/src
    module load mkl/10.2
+   module swap numpy numpy/1.8.1
 fi
 
 if [ "$NERSC_HOST" == "hopper" ]

--- a/MPenv/mpenv_static/BASH_template.txt
+++ b/MPenv/mpenv_static/BASH_template.txt
@@ -4,7 +4,7 @@ alias use_$$NAME='source $$ACTIVATE; export FW_CONFIG_FILE=$FW_CONFIG_$$NAME; ex
 
 alias update_codes='python $SCRIPT_LOC/update_codes.py'
 
-if [ "$NERSC_HOST" == "carver" ]
+if [ "$NERSC_HOST" == "matgen" ]
 then
    module load python/2.7.3
    export FW_CONFIG_$$NAME='$$CONFIG_LOC/config_Mendel/FW_config.yaml'

--- a/MPenv/mpenv_static/BASH_template.txt
+++ b/MPenv/mpenv_static/BASH_template.txt
@@ -7,7 +7,6 @@ alias update_codes='python $SCRIPT_LOC/update_codes.py'
 if [ "$NERSC_HOST" == "matgen" ]
 then
    module load vim
-   module unload intel
    module load python/2.7.3
    module swap numpy numpy/1.8.1
    module load virtualenv

--- a/MPenv/mpenv_static/BASH_template.txt
+++ b/MPenv/mpenv_static/BASH_template.txt
@@ -12,8 +12,6 @@ then
    module swap numpy numpy/1.8.1
    module load virtualenv
    module load virtualenvwrapper
-   module use /usr/common/das/Modules/modulefiles
-   module load vasp/5.2
    export FW_CONFIG_$$NAME='$$CONFIG_LOC/config_Mendel/FW_config.yaml'
    # Load Boltztrap
    export PATH=$PATH:/project/projectdirs/matgen/boltztrap/boltztrap-1.2.3/src

--- a/MPenv/mpenv_static/BASH_template.txt
+++ b/MPenv/mpenv_static/BASH_template.txt
@@ -6,14 +6,19 @@ alias update_codes='python $SCRIPT_LOC/update_codes.py'
 
 if [ "$NERSC_HOST" == "matgen" ]
 then
+   module purge
+   module load intel
+   module load openmpi
    module load python/2.7.3
+   module swap numpy numpy/1.8.1
+   module use /usr/syscom/opt/slurm/modulefiles
+   module load slurm
+   module use /usr/common/das/Modules/modulefiles
+   module load vasp/5.2
    export FW_CONFIG_$$NAME='$$CONFIG_LOC/config_Mendel/FW_config.yaml'
    # Load Boltztrap
    export PATH=$PATH:/project/projectdirs/matgen/boltztrap/boltztrap-1.2.3/src
    module load mkl/10.2
-   module swap numpy numpy/1.8.1
-   module use /usr/syscom/opt/slurm/modulefiles
-   module load slurm
 fi
 
 if [ "$NERSC_HOST" == "hopper" ]

--- a/MPenv/mpenv_static/BASH_template.txt
+++ b/MPenv/mpenv_static/BASH_template.txt
@@ -12,6 +12,8 @@ then
    export PATH=$PATH:/project/projectdirs/matgen/boltztrap/boltztrap-1.2.3/src
    module load mkl/10.2
    module swap numpy numpy/1.8.1
+   module use /usr/syscom/opt/slurm/modulefiles
+   module load slurm
 fi
 
 if [ "$NERSC_HOST" == "hopper" ]

--- a/MPenv/mpenv_static/BASH_template.txt
+++ b/MPenv/mpenv_static/BASH_template.txt
@@ -7,11 +7,11 @@ alias update_codes='python $SCRIPT_LOC/update_codes.py'
 if [ "$NERSC_HOST" == "carver" ]
 then
    module load python/2.7.3
+   module load numpy/1.8.1
    export FW_CONFIG_$$NAME='$$CONFIG_LOC/config_Mendel/FW_config.yaml'
    # Load Boltztrap
    export PATH=$PATH:/project/projectdirs/matgen/boltztrap/boltztrap-1.2.3/src
    module load mkl/10.2
-   module swap numpy numpy/1.8.2
 fi
 
 if [ "$NERSC_HOST" == "hopper" ]

--- a/MPenv/mpenv_static/BASH_template.txt
+++ b/MPenv/mpenv_static/BASH_template.txt
@@ -6,13 +6,12 @@ alias update_codes='python $SCRIPT_LOC/update_codes.py'
 
 if [ "$NERSC_HOST" == "matgen" ]
 then
-   module purge
-   module load intel
-   module load openmpi
+   module load vim
+   module unload intel
    module load python/2.7.3
    module swap numpy numpy/1.8.1
-   module use /usr/syscom/opt/slurm/modulefiles
-   module load slurm
+   module load virtualenv
+   module load virtualenvwrapper
    module use /usr/common/das/Modules/modulefiles
    module load vasp/5.2
    export FW_CONFIG_$$NAME='$$CONFIG_LOC/config_Mendel/FW_config.yaml'

--- a/MPenv/mpenv_static/qadapter_Mendel.yaml
+++ b/MPenv/mpenv_static/qadapter_Mendel.yaml
@@ -9,15 +9,12 @@ account: matgen
 job_name: null
 pre_rocket: |
             #SBATCH --export=DB_LOC,FW_CONFIG_FILE,VENV_LOC
-            module purge
-            module load intel
-            module load openmpi
+            module unload intel
             module load python/2.7.3
             module swap numpy numpy/1.8.1
-            module use /usr/syscom/opt/slurm/modulefiles
-            module load slurm
             module use /usr/common/das/Modules/modulefiles
             module load vasp/5.2
+            module load mkl/10.2
             source $VENV_LOC
 
 post_rocket: null

--- a/MPenv/mpenv_static/qadapter_Mendel.yaml
+++ b/MPenv/mpenv_static/qadapter_Mendel.yaml
@@ -1,7 +1,7 @@
 _fw_name: CommonAdapter
 _fw_q_type: SLURM
 rocket_launch: rlaunch -c $$CONFIG_LOC/config_$$MACHINE singleshot
-nodes: 1
+nodes: 2
 ntasks_per_node: 16
 walltime: '24:00:00'
 queue: matgen_prior
@@ -9,11 +9,15 @@ account: matgen
 job_name: null
 pre_rocket: |
             #SBATCH --export=DB_LOC,FW_CONFIG_FILE,VENV_LOC
+            module purge
+            module load intel
+            module load openmpi
             module load python/2.7.3
             module swap numpy numpy/1.8.1
-            module load vasp/5.2.matgen
             module use /usr/syscom/opt/slurm/modulefiles
             module load slurm
+            module use /usr/common/das/Modules/modulefiles
+            module load vasp/5.2
             source $VENV_LOC
 
 post_rocket: null

--- a/MPenv/mpenv_static/qadapter_Mendel.yaml
+++ b/MPenv/mpenv_static/qadapter_Mendel.yaml
@@ -12,6 +12,8 @@ pre_rocket: |
             module load python/2.7.3
             module swap numpy numpy/1.8.1
             module load vasp/5.2.matgen
+            module use /usr/syscom/opt/slurm/modulefiles
+            module load slurm
             source $VENV_LOC
 
 post_rocket: null

--- a/MPenv/mpenv_static/qadapter_Mendel.yaml
+++ b/MPenv/mpenv_static/qadapter_Mendel.yaml
@@ -9,7 +9,7 @@ account: matgen
 job_name: null
 pre_rocket: |
             #SBATCH --export=DB_LOC,FW_CONFIG_FILE,VENV_LOC
-            module unload intel
+            module load intel
             module load python/2.7.3
             module swap numpy numpy/1.8.1
             module use /usr/common/das/Modules/modulefiles

--- a/MPenv/mpenv_static/qadapter_Mendel.yaml
+++ b/MPenv/mpenv_static/qadapter_Mendel.yaml
@@ -1,14 +1,14 @@
 _fw_name: CommonAdapter
-_fw_q_type: PBS
+_fw_q_type: SLURM
 rocket_launch: rlaunch -c $$CONFIG_LOC/config_$$MACHINE singleshot
-nnodes: 2
-ppnode: 16
+nodes: 1
+ntasks_per_node: 16
 walltime: '24:00:00'
 queue: matgen_reg
-account: matcomp
+account: matgen
 job_name: null
 pre_rocket: |
-            #PBS -v DB_LOC,FW_CONFIG_FILE,VENV_LOC
+            #SBATCH --export=DB_LOC,FW_CONFIG_FILE,VENV_LOC
             module load python/2.7.3
             module swap numpy numpy/1.8.1
             module load vasp/5.2.matgen

--- a/MPenv/mpenv_static/qadapter_Mendel.yaml
+++ b/MPenv/mpenv_static/qadapter_Mendel.yaml
@@ -4,7 +4,7 @@ rocket_launch: rlaunch -c $$CONFIG_LOC/config_$$MACHINE singleshot
 nodes: 1
 ntasks_per_node: 16
 walltime: '24:00:00'
-queue: matgen_reg
+queue: matgen_prior
 account: matgen
 job_name: null
 pre_rocket: |

--- a/MPenv/mpenv_static/qadapter_Mendel.yaml
+++ b/MPenv/mpenv_static/qadapter_Mendel.yaml
@@ -7,15 +7,6 @@ walltime: '24:00:00'
 queue: matgen_prior
 account: matgen
 job_name: null
-pre_rocket: |
-            #SBATCH --export=DB_LOC,FW_CONFIG_FILE,VENV_LOC
-            module load intel
-            module load python/2.7.3
-            module swap numpy numpy/1.8.1
-            module use /usr/common/das/Modules/modulefiles
-            module load vasp/5.2
-            module load mkl/10.2
-            source $VENV_LOC
-
+pre_rocket: null
 post_rocket: null
 logdir: $$CONFIG_LOC/logs

--- a/README.rst
+++ b/README.rst
@@ -22,16 +22,16 @@ Warnings
 Part 1 - Install the MPenv code at NERSC and request an environment
 -------------------------------------------------------------------
 
-1. Log into Edison. Since Carver is retired as of Sep-30-2015, you can also log into matgen.nersc.gov to submit jobs to Mendel. If you've previously set up your environment on Carver, you can simply re-use that environment on matgen (accessible through /global/homes). Hopper is scheduled to be retired by January 2016, so use it at your own risk.
+1. Log into Edison. Since Carver is retired as of Sep-30-2015, you can also log into ``matgen.nersc.gov`` to submit jobs to Mendel. Hopper is scheduled to be retired by January 2016, so use it at your own risk.
 
-2. Load necessary modules on Edison. Skip this on matgen (modules are loaded by default).::
+2. Load necessary modules on Edison. Skip this on matgen (modules are loaded by default)::
 
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
 
-3. Create virtual environment and install MPenv code.::
+3. Create virtual environment and install MPenv code::
 
     mkdir admin_env
     virtualenv admin_env
@@ -46,20 +46,16 @@ Part 1 - Install the MPenv code at NERSC and request an environment
    * If the ``git clone`` command fails, make sure your SSH key for the NERSC machine is registered under your GitHub username. This is done by typing ``ssh-keygen -t dsa`` (hit enter at all prompts) and then copying your ``~/.ssh/id_dsa.pub`` file to your Github account (log into github.com, click account settings at top-right, then the 'SSH keys' section).
    * ``git clone`` might also fail if you're using non-default ssh-key names configured in ``~/.ssh/config``. Please make sure to start the ssh-agent and add your private key in this case: ``eval `ssh-agent -s` && ssh-add <path-to-private-key>``
 
-3. Type::
+3. Type ``which mpenv``. If the installation was successful, the system should find an executable.
 
-    which mpenv
+4. Request an environment from an administrator (currently Patrick Huck; backup Anubhav Jain). The current procedure is just to send an email with a requested environment name, e.g. ``aj_vasp``. A good environment name should look like ``A_B`` where ``A`` is your initials and ``B`` is some SHORT description that will help you remember what the environment is for. another example: ``wc_surfaces``.
 
-   If the installation was successful, the system should find an executable.
-
-4. Request an environment from an administrator (currently Patrick Huck; backup Anubhav Jain). The current procedure is just to send an email with a requested environment name, e.g. "aj_vasp". A good environment name should look like "A_B" where "A" is your initials and "B" is some SHORT description that will help you remember what the environment is for. another example: "wc_surfaces".
-
-5. An administrator will create a suite of databases hosted at NERSC for you and send you back an archive (a.k.a tarball), let's call this `aj_vasp_files.tar.gz`. *Do not rename or change this archive in any way*.
+5. An administrator will create a suite of databases hosted at NERSC for you and send you back an archive (a.k.a tarball), let's call this ``aj_vasp_files.tar.gz``. *Do not rename or change this archive in any way*.
 
 6. Once you receive the tarball, move to the next part.
 
-Part 2 - Install at NERSC
--------------------------
+Part 2 - Install MP codes at NERSC
+----------------------------------
 
 1. Upload the tarball you received from an admin (e.g., ``aj_vasp_files.tar.gz``) via ``scp`` to your home directory at NERSC, log into Edison or matgen, and unpack it (i.e. ``tar -xvzf aj_vasp_files.tar.gz``). Remember to not change this archive or the resulting directory contents!
 
@@ -70,7 +66,7 @@ Part 2 - Install at NERSC
     module load virtualenv
     module load virtualenvwrapper
 
-3. the admin environment that allows you to use MPenv::
+3. activate the admin environment that allows you to use ``mpenv``::
 
     source admin_env/bin/activate
 
@@ -90,7 +86,7 @@ Part 2 - Install at NERSC
 
 7. Activate your environment by typing ``use_<ENV_NAME>``, e.g., ``use_aj_vasp``.
 
-7. Reset your databases by typing ``go_testing --clear -n 'reset'``.
+8. Reset your databases by typing ``go_testing --clear -n 'reset'``.
 
 If all this goes OK, your environment should be installed!
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Warnings
 Part 1 - Install the MPenv code at NERSC and request an environment
 -------------------------------------------------------------------
 
-1. Log into Edison. Since Carver is retired as of Sep-30-2015, you can also log into ``matgen.nersc.gov`` to submit jobs to Mendel. Hopper is scheduled to be retired by January 2016, so use it at your own risk.
+1. Log into Edison. Since Carver is retired as of Sep-30-2015, you can also log into ``matgen.nersc.gov`` to submit jobs to Mendel. If you cannot log into ``matgen.nersc.gov``, run ``id`` on another NERSC system (Hopper, Edison) and check that you're in the ``matcomp`` group. If not, request to be added to the group by sending an e-mail to an administrator (Patrick Huck). Hopper is scheduled to be retired by January 2016, so use it at your own risk.
 
 2. Load necessary modules. In the future, you'll be able to skip this on matgen (we're trying to get all necessary modules loaded by default)::
 

--- a/README.rst
+++ b/README.rst
@@ -75,20 +75,32 @@ Part 1 - Install the MPenv code at NERSC and request an environment
      ``~/.ssh/id_dsa.pub`` file to your Github account (log into github.com,
      click account settings at top-right, then the 'SSH keys' section).
 
-3. Type ``which mpenv``. If the installation was successful, the system should find an executable.
+3. Type ``which mpenv``. If the installation was successful, the system should
+   find an executable.
 
-4. Request an environment from an administrator (currently Patrick Huck; backup Anubhav Jain). The current procedure is just to send an email with a requested environment name, e.g. ``aj_vasp``. A good environment name should look like ``A_B`` where ``A`` is your initials and ``B`` is some SHORT description that will help you remember what the environment is for. another example: ``wc_surfaces``.
+4. Request an environment from an administrator (currently Patrick Huck; backup
+   Anubhav Jain). The current procedure is just to send an email with a
+   requested environment name, e.g. ``aj_vasp``. A good environment name should
+   look like ``A_B`` where ``A`` is your initials and ``B`` is some SHORT
+   description that will help you remember what the environment is for. another
+   example: ``wc_surfaces``.
 
-5. An administrator will create a suite of databases hosted at NERSC for you and send you back an archive (a.k.a tarball), let's call this ``aj_vasp_files.tar.gz``. *Do not rename or change this archive in any way*.
+5. An administrator will create a suite of databases hosted at NERSC for you
+   and send you back an archive (a.k.a tarball), let's call this
+   ``aj_vasp_files.tar.gz``. *Do not rename or change this archive in any way*.
 
 6. Once you receive the tarball, move to the next part.
 
 Part 2 - Install MP codes at NERSC
 ----------------------------------
 
-1. Upload the tarball you received from an admin (e.g., ``aj_vasp_files.tar.gz``) via ``scp`` to your home directory at NERSC, log into Edison or matgen, and unpack it (i.e. ``tar -xvzf aj_vasp_files.tar.gz``). Remember to not change this archive or the resulting directory contents!
+1. Upload the tarball you received from an admin (e.g.,
+   ``aj_vasp_files.tar.gz``) via ``scp`` to your home directory at NERSC, log
+   into Edison or matgen, and unpack it (i.e. ``tar -xvzf
+   aj_vasp_files.tar.gz``). Remember to not change this archive or the
+   resulting directory contents!
 
-2. Load the necessary modules (can be skipped on matgen in the future)::
+2. Load the necessary modules::
 
     # Edison
     module load python/2.7.9
@@ -104,7 +116,8 @@ Part 2 - Install MP codes at NERSC
     module load virtualenv
     module load virtualenvwrapper
 
-3. add GitHub ssh-key and activate the admin environment that allows you to use ``mpenv``::
+3. add GitHub ssh-key and activate the admin environment that allows you to use
+   ``mpenv``::
 
     eval `ssh-agent -s` && ssh-add <path-to-private-github-key>
     source admin_env/bin/activate
@@ -114,12 +127,17 @@ Part 2 - Install MP codes at NERSC
     mpenv aj_vasp
 
   .. note::
-   * Replace ``aj_vasp`` with whatever environment name you requested, e.g. ``wc_surfaces``.
-   * There is a ``--pymatpro`` option if you need to install pymatpro (people working with meta db builders might need this).
+   * Replace ``aj_vasp`` with whatever environment name you requested, e.g.
+     ``wc_surfaces``.
+   * There is a ``--pymatpro`` option if you need to install pymatpro (people
+     working with meta db builders might need this).
    * See note in part 1 if ``git clone`` fails here.
-   * The ``rubicon`` git clone might still fail and claim a not-existing repo if you don't have the correct permissions. Contact an administrator to be granted access.
+   * The ``rubicon`` git clone might still fail and claim a not-existing repo
+     if you don't have the correct permissions. Contact an administrator to be
+     granted access.
 
-5. A whole bunch of stuff will happen... just wait for it. Hopefully it will succeed at the end and create a new directory with your environment name.
+5. A whole bunch of stuff will happen... just wait for it. Hopefully it will
+   succeed at the end and create a new directory with your environment name.
 
 6. Log out and in to NERSC again (or ``source ~/.bashrc.ext``).
 
@@ -132,9 +150,19 @@ If all this goes OK, your environment should be installed!
 Part 3 - Customize your environment
 -----------------------------------
 
-There are many things about your environment that you can (and might have to) customize. Here are a few.
+There are many things about your environment that you can (and might have to)
+customize. Here are a few.
 
-1. Go to ``<ENV_NAME>/config/config_<MACHINE>`` where ``<ENV_NAME>`` is something like ``aj_vasp`` and ``<MACHINE>`` is either ``Mendel``, ``Hopper``, or ``Edison``. Modify ``my_qadapter.yaml`` so that queue scripts are submitted to the queue you want with the walltime, mppwidth, and account you want. You might want to change the queue to "debug" for example in order to test your environment. If the ``account`` field says ``jcesr`` but you are not a member of the ``jcesr`` NERSC repository, either delete the ``account`` field or change to an account that you can charge at NERSC. If you are using Hopper to run VASP, you *must* change the mppwidth to 48. Repeat for all machines that you're using.
+1. Go to ``<ENV_NAME>/config/config_<MACHINE>`` where ``<ENV_NAME>`` is
+   something like ``aj_vasp`` and ``<MACHINE>`` is either ``Mendel``,
+   ``Hopper``, or ``Edison``. Modify ``my_qadapter.yaml`` so that queue scripts
+   are submitted to the queue you want with the walltime, mppwidth, and account
+   you want. You might want to change the queue to "debug" for example in order
+   to test your environment. If the ``account`` field says ``jcesr`` but you
+   are not a member of the ``jcesr`` NERSC repository, either delete the
+   ``account`` field or change to an account that you can charge at NERSC. If
+   you are using Hopper to run VASP, you *must* change the mppwidth to 48.
+   Repeat for all machines that you're using.
 
 2. Since ``Mendel`` is using SLURM, you'll also need to add the following to
    ``my_fworker.yaml`` to run VASP on multiple nodes in parallel::
@@ -142,43 +170,70 @@ There are many things about your environment that you can (and might have to) cu
     env:
         mpi_cmd: srun
 
-3. In your ``.bashrc.ext``, you'll want to add two lines (if not already done by ``mpenv``)::
+3. In your ``.bashrc.ext``, you'll want to add two lines (if not already done
+   by ``mpenv``)::
 
     export VASP_PSP_DIR=<PATH_TO_POTCARS>
     export MAPI_KEY=<MAPI_KEY>
 
-   where <PATH_TO_POTCARS> contains your POTCARs dir and MAPI_KEY is your Materials Project API key. See the pymatgen docs for more details. Some features of the code (e.g. VASP input generation) won't work without these. Note that members of the ``matgen`` group at NERSC should be able to set their <PATH_TO_POTCARS> as ``/project/projectdirs/matgen/POTCARs``.
+   where <PATH_TO_POTCARS> contains your POTCARs dir and MAPI_KEY is your
+   Materials Project API key. See the pymatgen docs for more details. Some
+   features of the code (e.g. VASP input generation) won't work without these.
+   Note that members of the ``matgen`` group at NERSC should be able to set
+   their <PATH_TO_POTCARS> as ``/project/projectdirs/matgen/POTCARs``.
 
-3. If you modify your ``bashrc.ext``, remember the changes are not applied unless you type ``source ~/.bashrc.ext``.
+3. If you modify your ``bashrc.ext``, remember the changes are not applied
+   unless you type ``source ~/.bashrc.ext``.
 
 Part 4 - Modifying or updating your codebases
 ---------------------------------------------
 
 .. note:: Currently this only seems to work on Hopper due to strange NERSC updates messing with SSL certs.
 
-1. The codes installed with your environment are in ``<ENV_NAME>/codes``. If you modify these codes (e.g. change a workflow in MPWork's ``snl_to_wf()`` method) they will modify the behavior of your environment.
+1. The codes installed with your environment are in ``<ENV_NAME>/codes``. If
+   you modify these codes (e.g. change a workflow in MPWork's ``snl_to_wf()``
+   method) they will modify the behavior of your environment.
 
-2. Use the ``update_codes`` command to pull the latest changes from **all** codes. **Be careful!** If there is a merge conflict or other problem, the script won't tell you; you need to monitor the output to make sure the pull completed OK.
+2. Use the ``update_codes`` command to pull the latest changes from **all**
+   codes. **Be careful!** If there is a merge conflict or other problem, the
+   script won't tell you; you need to monitor the output to make sure the pull
+   completed OK.
 
-3. You can also ``git pull`` individually within the repos inside ``<ENV_NAMES>/codes``. If the version number changed, then you also need to run ``python setup.py develop``.
+3. You can also ``git pull`` individually within the repos inside
+   ``<ENV_NAMES>/codes``. If the version number changed, then you also need to
+   run ``python setup.py develop``.
 
 Running Jobs
 ============
 
-After getting your environment installed, you might want to run some test jobs. See the `MPWorks page <https://github.com/materialsproject/MPWorks>`_ for more details on how to do so.
+After getting your environment installed, you might want to run some test jobs.
+See the `MPWorks page <https://github.com/materialsproject/MPWorks>`_ for more
+details on how to do so.
 
 Updating your admin environment
 ===============================
 
-From time to time MPenv will have new features and you will want to update your admin environment. This is different than updating the codes itself - it is updating the code that *installs* the high-throughput codes. You can update MPenv without deleting any data you might have accumulated in your database (contact an admin if you want your DBs reset). However you should know that this will delete any configuration updates you made to your environment (e.g., ``my_qadapter.yaml``). If you want to retain these changes, copy the files you need to another directory and copy/merge them back after upgrading your admin environment.
+From time to time MPenv will have new features and you will want to update your
+admin environment. This is different than updating the codes itself - it is
+updating the code that *installs* the high-throughput codes. You can update
+MPenv without deleting any data you might have accumulated in your database
+(contact an admin if you want your DBs reset). However you should know that
+this will delete any configuration updates you made to your environment (e.g.,
+``my_qadapter.yaml``). If you want to retain these changes, copy the files you
+need to another directory and copy/merge them back after upgrading your admin
+environment.
 
 When you're ready to begin (logged into NERSC):
 
-1. Edit your ``.bashrc.ext`` file - look for the commented section referring to your environment name and delete that section. This will be rewritten when you reinstall the environment along with any new changes. ``mpenv`` will abort if you forget to do this and if the respective section already exists in ``.bashrc.ext``.
+1. Edit your ``.bashrc.ext`` file - look for the commented section referring to
+   your environment name and delete that section. This will be rewritten when
+   you reinstall the environment along with any new changes. ``mpenv`` will
+   abort if you forget to do this and if the respective section already exists
+   in ``.bashrc.ext``.
 
 2. Log out and in again to ensure a clean BASH environment.
 
-3. Load the necessary modules. Can be skipped on matgen in the near future::
+3. Load necessary modules::
 
     # Edison
     module load python/2.7.9
@@ -187,16 +242,16 @@ When you're ready to begin (logged into NERSC):
     module load virtualenvwrapper
 
     # matgen
+    module load vim
+    module unload intel
     module load python/2.7.3
     module swap numpy numpy/1.8.1
     module load virtualenv
     module load virtualenvwrapper
-    module use /usr/syscom/opt/slurm/modulefiles
-    module load slurm
 
+4. Add your GitHub sshkey and activate your admin environment::
 
-4. Activate your admin environment::
-
+    eval `ssh-agent -s` && ssh-add <path-to-private-github-key>
     source admin_env/bin/activate
 
 5. Pull admin environment changes::
@@ -209,7 +264,9 @@ When you're ready to begin (logged into NERSC):
     cd ~
     mpenv aj_vasp
 
-  .. note:: Replace ``aj_vasp`` with whatever environment name you requested, e.g. ``wc_surfaces``. Also, there is a ``--pymatpro`` option if you need to install pymatpro (people working with meta db builders might need this).
+  .. note:: Replace ``aj_vasp`` with whatever environment name you requested,
+  e.g. ``wc_surfaces``. Also, there is a ``--pymatpro`` option if you need to
+  install pymatpro (people working with meta db builders might need this).
 
 8. Log out and in to NERSC again, or ``source ~/.bashrc.ext``.
 
@@ -218,13 +275,16 @@ When you're ready to begin (logged into NERSC):
 Deleting your environment
 =========================
 
-If you ever want to remove your environment completely (this is different than resetting DBs), you should:
+If you ever want to remove your environment completely (this is different than
+resetting DBs), you should:
 
 #. Contact an administrator to tear down the DB backends
 
-#. Remove the entire directory containing your environment AND your files (e.g. ``aj_vasp`` and ``aj_vasp_files``)
+#. Remove the entire directory containing your environment AND your files (e.g.
+   ``aj_vasp`` and ``aj_vasp_files``)
 
-#. Edit your ``.bashrc.ext`` file - look for the commented section referring to your environment name and delete that section.
+#. Edit your ``.bashrc.ext`` file - look for the commented section referring to
+   your environment name and delete that section.
 
 Administrator instructions
 ==========================
@@ -232,21 +292,29 @@ Administrator instructions
 Creating an admin_env
 ---------------------
 
-#. Start by creating the admin_env from the instructions listed for users. You might already have one installed if you've created an MPEnv in the past.
+#. Start by creating the admin_env from the instructions listed for users. You
+   might already have one installed if you've created an MPEnv in the past.
 
-#. You will need a directory called admin_env/MP_env/MP_env/private that contains the DB credentials for making an environment. Obtain this from someone who is currently an admin.
+#. You will need a directory called admin_env/MP_env/MP_env/private that
+   contains the DB credentials for making an environment. Obtain this from
+   someone who is currently an admin.
 
-#. Once you have the private dir in the correct spot, you have a working admin_env!
+#. Once you have the private dir in the correct spot, you have a working
+   admin_env!
 
 Managing an admin_env
 ---------------------
 
 #. Activate your ``admin_env`` environment.
 
-#. ``cd`` in your admin_env/MP_env directory, and then run ``git pull`` and (maybe) ``python setup.py develop``.
+#. ``cd`` in your admin_env/MP_env directory, and then run ``git pull`` and
+   (maybe) ``python setup.py develop``.
 
-#. Start in a directory where you archive all the environments that you've made. For me, it is ``$HOME/envs``.
+#. Start in a directory where you archive all the environments that you've
+   made. For me, it is ``$HOME/envs``.
 
-#. Type ``mpdbmake <ENV_NAME> <TYPE>`` where <ENV_NAME> is the name the user requested and <TYPE> is either ``FW`` or ``MP`` or ``rubicon``.
+#. Type ``mpdbmake <ENV_NAME> <TYPE>`` where <ENV_NAME> is the name the user
+   requested and <TYPE> is either ``FW`` or ``MP`` or ``rubicon``.
 
-#. Usually, I tar.gz the resulting DB files and send them to the user by email. But other methods would also be OK. I keep a copy in my envs directory.
+#. Usually, I tar.gz the resulting DB files and send them to the user by email.
+   But other methods would also be OK. I keep a copy in my envs directory.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,8 @@
 MPenv
 =====
 
-This codebase helps users create a virtual environment for running FireWorks within Materials Project in a semi-automated way.
+This codebase helps users create a virtual environment for running FireWorks
+within Materials Project in a semi-automated way.
 
 
 User instructions
@@ -11,20 +12,34 @@ User instructions
 Warnings
 --------
 
-1. If you are planning on running VASP or any other commercial code, make sure you have communicated your license to NERSC and have access to running it. The MPEnv will not give you access to any codes for which you are not a licensed user.
+1. If you are planning on running VASP or any other commercial code, make sure
+   you have communicated your license to NERSC and have access to running it.
+   The MPEnv will not give you access to any codes for which you are not a
+   licensed user.
 
 2. This only works on NERSC
 
-3. This only works if your NERSC shell is BASH, not CSH. Note that by default NERSC often sets CSH. **Seriously, BASH needs to be your DEFAULT shell. You cannot just start bash within CSH or virtualenv fails at NERSC.** To change your default shell, login to nim.nersc.gov, go to 'Logins by host', then 'change login shell', then change your shells. Type `echo $SHELL` when logged in to confirm that your shell is BASH (e.g. `/bin/bash`).
+3. This only works if your NERSC shell is BASH, not CSH. Note that by default
+   NERSC often sets CSH. **Seriously, BASH needs to be your DEFAULT shell. You
+   cannot just start bash within CSH or virtualenv fails at NERSC.** To change
+   your default shell, login to nim.nersc.gov, go to 'Logins by host', then
+   'change login shell', then change your shells. Type `echo $SHELL` when
+   logged in to confirm that your shell is BASH (e.g. `/bin/bash`).
 
-4. After creating your environment, you can't move or rename it. If you need to delete it see the instructions below.
+4. After creating your environment, you can't move or rename it. If you need to
+   delete it see the instructions below.
 
 Part 1 - Install the MPenv code at NERSC and request an environment
 -------------------------------------------------------------------
 
-1. Log into Edison. Since Carver is retired as of Sep-30-2015, you can also log into ``matgen.nersc.gov`` to submit jobs to Mendel. If you cannot log into ``matgen.nersc.gov``, run ``id`` on another NERSC system (Hopper, Edison) and check that you're in the ``matcomp`` group. If not, request to be added to the group by sending an e-mail to an administrator (Patrick Huck). Hopper is scheduled to be retired by January 2016, so use it at your own risk.
+1. Log into Edison. Since Carver is retired as of Sep-30-2015, you can also log
+   into ``matgen.nersc.gov`` to submit jobs to Mendel. If you cannot log into
+   ``matgen.nersc.gov``, run ``id`` on another NERSC system (Hopper, Edison)
+   and check that you're in the ``matcomp`` group. If not, request to be added
+   to the group by sending an e-mail to an administrator (Patrick Huck). Hopper
+   is scheduled to be retired by January 2016, so use it at your own risk.
 
-2. Load necessary modules. In the future, you'll be able to skip this on matgen (we're trying to get all necessary modules loaded by default)::
+2. Load necessary modules::
 
     # Edison
     module load python/2.7.9
@@ -52,8 +67,13 @@ Part 1 - Install the MPenv code at NERSC and request an environment
     python setup.py develop
 
   .. note::
-   * If the virtualenv command fails, make sure you have set your *default* shell to be BASH and not CSH.
-   * If the ``git clone`` command fails, make sure your SSH key for the NERSC machine is registered under your GitHub username. This is done by typing ``ssh-keygen -t dsa`` (hit enter at all prompts) and then copying your ``~/.ssh/id_dsa.pub`` file to your Github account (log into github.com, click account settings at top-right, then the 'SSH keys' section).
+   * If the virtualenv command fails, make sure you have set your *default*
+     shell to be BASH and not CSH.
+   * If the ``git clone`` command fails, make sure your SSH key for the NERSC
+     machine is registered under your GitHub username. This is done by typing
+     ``ssh-keygen -t dsa`` (hit enter at all prompts) and then copying your
+     ``~/.ssh/id_dsa.pub`` file to your Github account (log into github.com,
+     click account settings at top-right, then the 'SSH keys' section).
 
 3. Type ``which mpenv``. If the installation was successful, the system should find an executable.
 

--- a/README.rst
+++ b/README.rst
@@ -22,15 +22,17 @@ Warnings
 Part 1 - Install the MPenv code at NERSC and request an environment
 -------------------------------------------------------------------
 
-1. Log into Edison. Carver is scheduled to be retired by October 2015, and
-   Hopper is scheduled to be retired by January 2016, so use those systems at your own risk.
+1. Log into Edison. Since Carver is retired as of Sep-30-2015, you can also log into matgen.nersc.gov to submit jobs to Mendel. If you've previously set up your environment on Carver, you can simply re-use that environment on matgen (accessible through /global/homes). Hopper is scheduled to be retired by January 2016, so use it at your own risk.
 
-2. Type::
+2. Load necessary modules on Edison. Skip this on matgen (modules are loaded by default).::
 
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
+
+3. Create virtual environment and install MPenv code.::
+
     mkdir admin_env
     virtualenv admin_env
     source admin_env/bin/activate
@@ -39,9 +41,10 @@ Part 1 - Install the MPenv code at NERSC and request an environment
     cd MPenv
     python setup.py develop
 
-
-  .. note:: If the virtualenv command fails, make sure you have set your *default* shell to be BASH and not CSH.
-  .. note:: If the ``git clone`` command fails, make sure your SSH key for the NERSC machine is registered under your GitHub username. This is done by typing ``ssh-keygen -t dsa`` (hit enter at all prompts) and then copying your ``~/.ssh/id_dsa.pub`` file to your Github account (log into github.com, click account settings at top-right, then the 'SSH keys' section). ``git clone`` might also fail if you're using non-default ssh-key names configured in ``~/.ssh/config``. Please make sure to start the ssh-agent and add your private key in this case: ``eval `ssh-agent -s` && ssh-add <path-to-private-key>``
+  .. note::
+   * If the virtualenv command fails, make sure you have set your *default* shell to be BASH and not CSH.
+   * If the ``git clone`` command fails, make sure your SSH key for the NERSC machine is registered under your GitHub username. This is done by typing ``ssh-keygen -t dsa`` (hit enter at all prompts) and then copying your ``~/.ssh/id_dsa.pub`` file to your Github account (log into github.com, click account settings at top-right, then the 'SSH keys' section).
+   * ``git clone`` might also fail if you're using non-default ssh-key names configured in ``~/.ssh/config``. Please make sure to start the ssh-agent and add your private key in this case: ``eval `ssh-agent -s` && ssh-add <path-to-private-key>``
 
 3. Type::
 
@@ -51,48 +54,43 @@ Part 1 - Install the MPenv code at NERSC and request an environment
 
 4. Request an environment from an administrator (currently Patrick Huck; backup Anubhav Jain). The current procedure is just to send an email with a requested environment name, e.g. "aj_vasp". A good environment name should look like "A_B" where "A" is your initials and "B" is some SHORT description that will help you remember what the environment is for. another example: "wc_surfaces".
 
-5. An administrator will create a suite of databases hosted at NERSC for you and send you back a directory, lets call this "aj_vasp_files". *Do not rename or change this directory in any way*.
+5. An administrator will create a suite of databases hosted at NERSC for you and send you back an archive (a.k.a tarball), let's call this `aj_vasp_files.tar.gz`. *Do not rename or change this archive in any way*.
 
-6. Once you receive the directory, move to the next part.
+6. Once you receive the tarball, move to the next part.
 
 Part 2 - Install at NERSC
 -------------------------
 
-1. Upload the entire files directory you received from an admin (e.g., *aj_vasp_files*) to your home directory at NERSC. Remember to not change this directory!
+1. Upload the tarball you received from an admin (e.g., ``aj_vasp_files.tar.gz``) via ``scp`` to your home directory at NERSC, log into Edison or matgen, and unpack it (i.e. ``tar -xvzf aj_vasp_files.tar.gz``). Remember to not change this archive or the resulting directory contents!
 
-2. Log into Edison and enter the admin environment that allows you to use MPenv::
+2. Load the necessary modules on Edison (skip this on matgen):: 
 
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
+
+3. the admin environment that allows you to use MPenv::
+
     source admin_env/bin/activate
 
-3. Now, you can install your environment. Staying in your home directory, type::
+4. Now, you can install your environment. Staying in your home directory, type::
 
     mpenv aj_vasp
 
-  .. note:: Replace ``aj_vasp`` with whatever environment name you requested, e.g. ``wc_surfaces``. There is a ``--pymatpro`` option if you need to install pymatpro (people working with meta db builders might need this). See note in part 1 if ``git clone`` fails here. The ``rubicon`` clone might still fail and claim a not-existing repo if you don't have the correct permissions. Contact an administrator to be granted access.
-  
-  .. note:: The "aj_vasp" must currently be a *directory*. If you received a .tar.gz file, you should unzip and untar it first
+  .. note::
+   * Replace ``aj_vasp`` with whatever environment name you requested, e.g. ``wc_surfaces``.
+   * There is a ``--pymatpro`` option if you need to install pymatpro (people working with meta db builders might need this).
+   * See note in part 1 if ``git clone`` fails here.
+   * The ``rubicon`` git clone might still fail and claim a not-existing repo if you don't have the correct permissions. Contact an administrator to be granted access.
 
-4. A whole bunch of stuff will happen...just wait for it. Hopefully it will succeed at the end and create a new directory with your environment name.
+5. A whole bunch of stuff will happen... just wait for it. Hopefully it will succeed at the end and create a new directory with your environment name.
 
-5. Type::
+6. Log out and in to NERSC again (or ``source ~/.bashrc.ext``).
 
-   source ~/.bashrc.ext
+7. Activate your environment by typing ``use_<ENV_NAME>``, e.g., ``use_aj_vasp``.
 
-  (or log out and log into NERSC again)
-
-6. Activate your environment by typing::
-
-   use_<ENV_NAME>
-
-  e.g., ``use_aj_vasp``.
-
-7. Reset your databases by typing::
-
-    go_testing --clear -n 'reset'
+7. Reset your databases by typing ``go_testing --clear -n 'reset'``.
 
 If all this goes OK, your environment should be installed!
 
@@ -144,20 +142,25 @@ When you're ready to begin (logged into Edison):
 
 2. Delete the entire directory containing your environment. (e.g. ``aj_vasp``). *Make sure you do NOT delete your files directory, e.g. ``aj_vasp_files``. If you lose this directory contact an admin, they can fix it!*
 
-3. Activate your admin environment::
+3. Log out and in again to ensure a clean BASH environment.
+
+3. Load the necessary modules. Skip this on matgen (necessary modules are pre-loaded automatically)::
 
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
+
+4. Activate your admin environment::
+
     source admin_env/bin/activate
 
-4. Pull admin environment changes::
+5. Pull admin environment changes::
 
     cd admin_env/MPenv
     git pull
 
-5. Go back to your home directory and reinstall the virutalenv::
+6. Go back to your home directory and reinstall the virtualenv::
 
     cd ~
     mpenv aj_vasp

--- a/README.rst
+++ b/README.rst
@@ -24,12 +24,21 @@ Part 1 - Install the MPenv code at NERSC and request an environment
 
 1. Log into Edison. Since Carver is retired as of Sep-30-2015, you can also log into ``matgen.nersc.gov`` to submit jobs to Mendel. Hopper is scheduled to be retired by January 2016, so use it at your own risk.
 
-2. Load necessary modules on Edison. Skip this on matgen (modules are loaded by default)::
+2. Load necessary modules. In the future, you'll be able to skip this on matgen (we're trying to get all necessary modules loaded by default)::
 
+    # Edison
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
+    
+    # matgen
+    module load python/2.7.3
+    module swap numpy numpy/1.8.1
+    module load virtualenv
+    module load virtualenvwrapper
+    module use /usr/syscom/opt/slurm/modulefiles
+    module load slurm
 
 3. Create virtual environment and install MPenv code::
 
@@ -59,12 +68,22 @@ Part 2 - Install MP codes at NERSC
 
 1. Upload the tarball you received from an admin (e.g., ``aj_vasp_files.tar.gz``) via ``scp`` to your home directory at NERSC, log into Edison or matgen, and unpack it (i.e. ``tar -xvzf aj_vasp_files.tar.gz``). Remember to not change this archive or the resulting directory contents!
 
-2. Load the necessary modules on Edison (skip this on matgen):: 
+2. Load the necessary modules (can be skipped on matgen in the future):: 
 
+    # Edison
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
+    
+    # matgen
+    module load python/2.7.3
+    module swap numpy numpy/1.8.1
+    module load virtualenv
+    module load virtualenvwrapper
+    module use /usr/syscom/opt/slurm/modulefiles
+    module load slurm
+
 
 3. activate the admin environment that allows you to use ``mpenv``::
 
@@ -133,12 +152,22 @@ When you're ready to begin (logged into NERSC):
 
 2. Log out and in again to ensure a clean BASH environment.
 
-3. Load the necessary modules. Skip this on matgen (modules are pre-loaded automatically)::
+3. Load the necessary modules. Can be skipped on matgen in the near future::
 
+    # Edison
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
+    
+    # matgen
+    module load python/2.7.3
+    module swap numpy numpy/1.8.1
+    module load virtualenv
+    module load virtualenvwrapper
+    module use /usr/syscom/opt/slurm/modulefiles
+    module load slurm
+
 
 4. Activate your admin environment::
 

--- a/README.rst
+++ b/README.rst
@@ -31,14 +31,14 @@ Part 1 - Install the MPenv code at NERSC and request an environment
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
-    
+
     # matgen
+    module load vim
+    module unload intel
     module load python/2.7.3
     module swap numpy numpy/1.8.1
     module load virtualenv
     module load virtualenvwrapper
-    module use /usr/syscom/opt/slurm/modulefiles
-    module load slurm
 
 3. Create virtual environment and install MPenv code::
 
@@ -46,6 +46,7 @@ Part 1 - Install the MPenv code at NERSC and request an environment
     virtualenv admin_env
     source admin_env/bin/activate
     cd admin_env
+    eval `ssh-agent -s` && ssh-add <path-to-private-github-key>
     git clone git@github.com:materialsproject/MPenv.git
     cd MPenv
     python setup.py develop
@@ -53,7 +54,6 @@ Part 1 - Install the MPenv code at NERSC and request an environment
   .. note::
    * If the virtualenv command fails, make sure you have set your *default* shell to be BASH and not CSH.
    * If the ``git clone`` command fails, make sure your SSH key for the NERSC machine is registered under your GitHub username. This is done by typing ``ssh-keygen -t dsa`` (hit enter at all prompts) and then copying your ``~/.ssh/id_dsa.pub`` file to your Github account (log into github.com, click account settings at top-right, then the 'SSH keys' section).
-   * ``git clone`` might also fail if you're using non-default ssh-key names configured in ``~/.ssh/config``. Please make sure to start the ssh-agent and add your private key in this case: ``eval `ssh-agent -s` && ssh-add <path-to-private-key>``
 
 3. Type ``which mpenv``. If the installation was successful, the system should find an executable.
 
@@ -68,25 +68,25 @@ Part 2 - Install MP codes at NERSC
 
 1. Upload the tarball you received from an admin (e.g., ``aj_vasp_files.tar.gz``) via ``scp`` to your home directory at NERSC, log into Edison or matgen, and unpack it (i.e. ``tar -xvzf aj_vasp_files.tar.gz``). Remember to not change this archive or the resulting directory contents!
 
-2. Load the necessary modules (can be skipped on matgen in the future):: 
+2. Load the necessary modules (can be skipped on matgen in the future)::
 
     # Edison
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
-    
+
     # matgen
+    module load vim
+    module unload intel
     module load python/2.7.3
     module swap numpy numpy/1.8.1
     module load virtualenv
     module load virtualenvwrapper
-    module use /usr/syscom/opt/slurm/modulefiles
-    module load slurm
 
+3. add GitHub ssh-key and activate the admin environment that allows you to use ``mpenv``::
 
-3. activate the admin environment that allows you to use ``mpenv``::
-
+    eval `ssh-agent -s` && ssh-add <path-to-private-github-key>
     source admin_env/bin/activate
 
 4. Now, you can install your environment. Staying in your home directory, type::
@@ -116,7 +116,13 @@ There are many things about your environment that you can (and might have to) cu
 
 1. Go to ``<ENV_NAME>/config/config_<MACHINE>`` where ``<ENV_NAME>`` is something like ``aj_vasp`` and ``<MACHINE>`` is either ``Mendel``, ``Hopper``, or ``Edison``. Modify ``my_qadapter.yaml`` so that queue scripts are submitted to the queue you want with the walltime, mppwidth, and account you want. You might want to change the queue to "debug" for example in order to test your environment. If the ``account`` field says ``jcesr`` but you are not a member of the ``jcesr`` NERSC repository, either delete the ``account`` field or change to an account that you can charge at NERSC. If you are using Hopper to run VASP, you *must* change the mppwidth to 48. Repeat for all machines that you're using.
 
-2. In your ``.bashrc.ext``, you'll want to add two lines (if not already done by ``mpenv``)::
+2. Since ``Mendel`` is using SLURM, you'll also need to add the following to
+   ``my_fworker.yaml`` to run VASP on multiple nodes in parallel::
+
+    env:
+        mpi_cmd: srun
+
+3. In your ``.bashrc.ext``, you'll want to add two lines (if not already done by ``mpenv``)::
 
     export VASP_PSP_DIR=<PATH_TO_POTCARS>
     export MAPI_KEY=<MAPI_KEY>
@@ -159,7 +165,7 @@ When you're ready to begin (logged into NERSC):
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
-    
+
     # matgen
     module load python/2.7.3
     module swap numpy numpy/1.8.1
@@ -182,7 +188,7 @@ When you're ready to begin (logged into NERSC):
 
     cd ~
     mpenv aj_vasp
-    
+
   .. note:: Replace ``aj_vasp`` with whatever environment name you requested, e.g. ``wc_surfaces``. Also, there is a ``--pymatpro`` option if you need to install pymatpro (people working with meta db builders might need this).
 
 8. Log out and in to NERSC again, or ``source ~/.bashrc.ext``.

--- a/README.rst
+++ b/README.rst
@@ -95,9 +95,9 @@ Part 3 - Customize your environment
 
 There are many things about your environment that you can (and might have to) customize. Here are a few.
 
-1. Go to ``<ENV_NAME>/config/config_Hopper`` where <ENV_NAME> is something like ``aj_vasp``. Modify ``my_qadapter.yaml`` so that queue scripts are submitted to the queue you want with the walltime, mppwidth, and account you want. You might want to change the queue to "debug" for example in order to test your environment. If you are not a member of the ``jcesr`` NERSC repository, either delete the ``account`` field or change to an account that you can charge at NERSC.  Do the same thing for ``config_Mendel``. (Note: Carver is not currently supported) If you are using Hopper to run VASP, you *must* change the mppwidth to 48.
+1. Go to ``<ENV_NAME>/config/config_<MACHINE>`` where ``<ENV_NAME>`` is something like ``aj_vasp`` and ``<MACHINE>`` is either ``Mendel``, ``Hopper``, or ``Edison``. Modify ``my_qadapter.yaml`` so that queue scripts are submitted to the queue you want with the walltime, mppwidth, and account you want. You might want to change the queue to "debug" for example in order to test your environment. If the ``account`` field says ``jcesr`` but you are not a member of the ``jcesr`` NERSC repository, either delete the ``account`` field or change to an account that you can charge at NERSC. If you are using Hopper to run VASP, you *must* change the mppwidth to 48. Repeat for all machines that you're using.
 
-2. In your ``.bashrc.ext``, you'll want to add two lines::
+2. In your ``.bashrc.ext``, you'll want to add two lines (if not already done by ``mpenv``)::
 
     export VASP_PSP_DIR=<PATH_TO_POTCARS>
     export MAPI_KEY=<MAPI_KEY>
@@ -122,46 +122,39 @@ Running Jobs
 
 After getting your environment installed, you might want to run some test jobs. See the `MPWorks page <https://github.com/materialsproject/MPWorks>`_ for more details on how to do so.
 
-Updating your environment itself
-================================
+Updating your admin environment
+===============================
 
-From time to time MPenv will have new features and you will want to update your environment. This is different than updating the codes itself - it is updating the code that *installs* the high-throughput codes. You can update MPenv without deleting any data you might have accumulated in your database (contact an admin if you want your DBs reset). However you should know that:
+From time to time MPenv will have new features and you will want to update your admin environment. This is different than updating the codes itself - it is updating the code that *installs* the high-throughput codes. You can update MPenv without deleting any data you might have accumulated in your database (contact an admin if you want your DBs reset). However you should know that this will delete any configuration updates you made to your environment (e.g., ``my_qadapter.yaml``). If you want to retain these changes, copy the files you need to another directory and copy/merge them back after upgrading your admin environment.
 
-* this will delete any code updates you made to your environment unless they are backed up on git
-* this will delete any configuration updates you made to your environment (e.g., ``my_qadapter.yaml``)
-
-If you want to retain these changes, copy the files you need to another directory and copy them back after upgrading your environment.
-
-When you're ready to begin (logged into Edison):
+When you're ready to begin (logged into NERSC):
 
 1. Edit your ``.bashrc.ext`` file - look for the commented section referring to your environment name and delete that section. This will be rewritten when you reinstall the environment along with any new changes.
 
-2. Delete the entire directory containing your environment. (e.g. ``aj_vasp``). *Make sure you do NOT delete your files directory, e.g. ``aj_vasp_files``. If you lose this directory contact an admin, they can fix it!*
+2. Log out and in again to ensure a clean BASH environment.
 
-3. Log out and in again to ensure a clean BASH environment.
-
-4. Load the necessary modules. Skip this on matgen (modules are pre-loaded automatically)::
+3. Load the necessary modules. Skip this on matgen (modules are pre-loaded automatically)::
 
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
 
-5. Activate your admin environment::
+4. Activate your admin environment::
 
     source admin_env/bin/activate
 
-6. Pull admin environment changes::
+5. Pull admin environment changes::
 
     cd admin_env/MPenv
     git pull
 
-7. Go back to your home directory and reinstall the virtualenv::
+6. Go back to your home directory and reinstall::
 
     cd ~
     mpenv aj_vasp
     
-  .. note:: Replace ``aj_vasp`` with whatever environment name you requested, e.g. ``wc_surfaces``. Also, there is a ``--pymatpro`` option if you need to install pymatpro (people working with meta db builders might need this). If you get an error regarding PyCIFRW, try ``--alternate_pycifrw``.
+  .. note:: Replace ``aj_vasp`` with whatever environment name you requested, e.g. ``wc_surfaces``. Also, there is a ``--pymatpro`` option if you need to install pymatpro (people working with meta db builders might need this).
 
 8. Log out and in to NERSC again, or ``source ~/.bashrc.ext``.
 

--- a/README.rst
+++ b/README.rst
@@ -140,31 +140,32 @@ When you're ready to begin (logged into Edison):
 
 3. Log out and in again to ensure a clean BASH environment.
 
-3. Load the necessary modules. Skip this on matgen (necessary modules are pre-loaded automatically)::
+4. Load the necessary modules. Skip this on matgen (modules are pre-loaded automatically)::
 
     module load python/2.7.9
     module load numpy/1.9.2
     module load virtualenv
     module load virtualenvwrapper
 
-4. Activate your admin environment::
+5. Activate your admin environment::
 
     source admin_env/bin/activate
 
-5. Pull admin environment changes::
+6. Pull admin environment changes::
 
     cd admin_env/MPenv
     git pull
 
-6. Go back to your home directory and reinstall the virtualenv::
+7. Go back to your home directory and reinstall the virtualenv::
 
     cd ~
     mpenv aj_vasp
-    source ~/.bashrc.ext
-
+    
   .. note:: Replace ``aj_vasp`` with whatever environment name you requested, e.g. ``wc_surfaces``. Also, there is a ``--pymatpro`` option if you need to install pymatpro (people working with meta db builders might need this). If you get an error regarding PyCIFRW, try ``--alternate_pycifrw``.
 
-6. Finally, remember to go back and make any configuration or code changes you need!
+8. Log out and in to NERSC again, or ``source ~/.bashrc.ext``.
+
+9. Finally, remember to go back and make any configuration or code changes you need!
 
 Deleting your environment
 =========================

--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ From time to time MPenv will have new features and you will want to update your 
 
 When you're ready to begin (logged into NERSC):
 
-1. Edit your ``.bashrc.ext`` file - look for the commented section referring to your environment name and delete that section. This will be rewritten when you reinstall the environment along with any new changes.
+1. Edit your ``.bashrc.ext`` file - look for the commented section referring to your environment name and delete that section. This will be rewritten when you reinstall the environment along with any new changes. ``mpenv`` will abort if you forget to do this and if the respective section already exists in ``.bashrc.ext``.
 
 2. Log out and in again to ensure a clean BASH environment.
 


### PR DESCRIPTION
This pull request updates the instructions in the README for the new Mendel login node `matgen.nersc.gov` following the retirement of Carver. The instructions will be further simplified once we've set up all necessary modules to be loaded on Mendel by default. The current [Mendel configuration](https://github.com/materialsproject/MPenv/blob/2203a98/MPenv/mpenv_static/qadapter_Mendel.yaml) uses 16 processes on only one node and `mpirun` instead of `srun`. This seems to make the test jobs for Si and Al very slow. @shreddd and @tschaume are working with NERSC on getting VASP to work with `srun` which should allow for the usage of two nodes with 32 processes in parallel. Also, @tschaume opened a couple of tickets regarding python/numpy upgrades and adjustment of the NERSC_HOST environment variable.

@montoyjh and @dwinston, would you mind giving the instructions a try? If you have an existing installation from Carver, you should only need to follow the [update instructions](https://github.com/materialsproject/MPenv/tree/matgen-instructions#updating-your-admin-environment). Let me know if you can get the Si and Al test jobs running, too.

@computron, could you skim over the [new version](https://github.com/materialsproject/MPenv/blob/1d452ed/MPenv/mpenv.py) of `mpenv`? It should only override/update configuration files and clone new code repositories. Existing code repos won't be touched.

@kristinpersson, FYI :-)
